### PR TITLE
Support multiple model uploads and selection

### DIFF
--- a/ARDemoApp/app/src/main/res/layout/activity_main.xml
+++ b/ARDemoApp/app/src/main/res/layout/activity_main.xml
@@ -11,11 +11,21 @@
         android:layout_width="match_parent"
         android:layout_height="match_parent" />
 
+    <Spinner
+        android:id="@+id/spinnerModels"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="16dp"
+        android:layout_marginEnd="16dp"
+        app:layout_constraintBottom_toTopOf="@+id/btnConnect"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent" />
+
     <Button
         android:id="@+id/btnConnect"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:text="Lấy Model từ Server"
+        android:text="Làm mới danh sách"
         android:layout_margin="16dp"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintStart_toStartOf="parent" />

--- a/MyARServer/public/index.html
+++ b/MyARServer/public/index.html
@@ -103,9 +103,9 @@
             <div class="drop-zone" id="dropZone">
                 <span class="icon">☁️</span>
                 <strong id="instruction-text">Click hoặc Kéo thả file vào đây</strong>
-                <div id="file-name-display"></div> <div class="file-hint">Hỗ trợ định dạng: .GLB, .GLTF</div>
-                
-                <input type="file" name="file" id="fileInput" accept=".glb, .gltf" required>
+                <div id="file-name-display"></div> <div class="file-hint">Có thể chọn nhiều file .GLB, .GLTF</div>
+
+                <input type="file" name="files" id="fileInput" accept=".glb, .gltf" multiple required>
             </div>
 
             <button type="submit" class="btn-upload" id="submitBtn">Tải lên Server</button>
@@ -122,8 +122,9 @@
         // 1. Hiệu ứng hiển thị tên file khi người dùng chọn
         fileInput.addEventListener('change', function() {
             if (this.files && this.files.length > 0) {
-                fileNameDisplay.textContent = this.files[0].name; // Hiện tên file
-                instructionText.style.display = 'none'; // Ẩn dòng hướng dẫn đi cho gọn
+                const names = Array.from(this.files).map(f => f.name).join(', ');
+                fileNameDisplay.textContent = names;
+                instructionText.style.display = 'none';
             }
         });
 
@@ -132,15 +133,15 @@
             e.preventDefault(); // Chặn việc load lại trang
 
             // Lấy file
-            const file = fileInput.files[0];
-            if (!file) {
+            const files = fileInput.files;
+            if (!files || files.length === 0) {
                 alert("Vui lòng chọn file trước!");
                 return;
             }
 
             // Tạo dữ liệu form để gửi
             const formData = new FormData();
-            formData.append('file', file); // 'file' là tên key mà server sẽ nhận
+            Array.from(files).forEach(file => formData.append('files', file));
 
             // Hiệu ứng đang tải...
             submitBtn.textContent = "Đang tải lên...";


### PR DESCRIPTION
## Summary
- allow uploading multiple GLB/GLTF files with unique names and expose an API to list them
- update web uploader UI to select and send multiple models at once
- update Android app to fetch the server model list, pick a model from a spinner, and place the selected asset in AR

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6948cfebb82c8328ad9e221c44613b38)