### PR TITLE
Add /api/models endpoint for Android model list

### DIFF
--- a/MyARServer/server.js
+++ b/MyARServer/server.js
@@ -87,6 +87,22 @@ app.get('/api/files', (req, res) => {
     }
 });
 
+// API trả về danh sách model cho ứng dụng Android
+app.get('/api/models', (req, res) => {
+    try {
+        // Ưu tiên host từ request để đảm bảo đúng IP/port khi deploy thực tế
+        const hostFromRequest = req.get('host');
+        const hostUrl = hostFromRequest ? `${req.protocol}://${hostFromRequest}` : `http://${SERVER_IP}:${PORT}`;
+
+        const models = getModelFiles(hostUrl)
+            .map(({ name, size, date, url }) => ({ name, size, date, url }));
+
+        res.json({ models });
+    } catch (error) {
+        res.status(500).json({ error: 'Lỗi server' });
+    }
+});
+
 // Xóa file
 app.delete('/api/files/:filename', (req, res) => {
     const filename = req.params.filename;


### PR DESCRIPTION
## Summary
- add an /api/models endpoint that returns available models with public URLs
- reuse the existing model discovery utility so Android clients can request model lists reliably

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694a740725b883289d8eab72f3e0f126)